### PR TITLE
Fix: Docker workflow version tag parsing for v0.3.1 release

### DIFF
--- a/.github/workflows/build-prod.yaml
+++ b/.github/workflows/build-prod.yaml
@@ -38,16 +38,22 @@ jobs:
           if [[ $TAG == strapi-v* ]]; then
             echo "build_strapi=true" >> $GITHUB_OUTPUT
             echo "build_web=false" >> $GITHUB_OUTPUT
-            echo "version=${TAG#strapi-}" >> $GITHUB_OUTPUT
+            # Strip 'strapi-v' prefix to get version (e.g., strapi-v0.3.0 -> 0.3.0)
+            VERSION=${TAG#strapi-v}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           elif [[ $TAG == web-v* ]]; then
             echo "build_strapi=false" >> $GITHUB_OUTPUT
             echo "build_web=true" >> $GITHUB_OUTPUT
-            echo "version=${TAG#web-}" >> $GITHUB_OUTPUT
+            # Strip 'web-v' prefix to get version (e.g., web-v0.3.0 -> 0.3.0)
+            VERSION=${TAG#web-v}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
             # Default tag format (v*.*.*) builds both
             echo "build_strapi=true" >> $GITHUB_OUTPUT
             echo "build_web=true" >> $GITHUB_OUTPUT
-            echo "version=$TAG" >> $GITHUB_OUTPUT
+            # Strip 'v' prefix to get version (e.g., v0.3.0 -> 0.3.0)
+            VERSION=${TAG#v}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           fi
 
   build-strapi:


### PR DESCRIPTION
Fixes the production build workflow to properly strip the 'v' prefix from version tags.

**Problem:** The semver metadata action expects versions without 'v' prefix (e.g., `0.3.0`), but we were passing `v0.3.0`, causing registry authentication failures during manifest push.

**Solution:** Strip the 'v' prefix in the detect-project job before passing to metadata action.

**Next:** After merging, create v0.3.1 patch release to test the fix.