### PR TITLE
fix: disable provenance attestations

### DIFF
--- a/.github/workflows/build-prod.yaml
+++ b/.github/workflows/build-prod.yaml
@@ -118,6 +118,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
 
   build-web:
     name: Build Web Image
@@ -181,3 +182,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false


### PR DESCRIPTION
Gitea doesn't properly support Docker BuildKit provenance attestations, causing OAuth token errors during manifest push. This was already disabled in the dev workflow but missing from production builds.