### PR TITLE
enhancement: extend DataDisplay component with ref support

### DIFF
--- a/web/src/shared/data-display/data-display.tsx
+++ b/web/src/shared/data-display/data-display.tsx
@@ -421,5 +421,5 @@ DataDisplayComponent.displayName = "DataDisplay";
 export const DataDisplay = React.forwardRef(DataDisplayComponent) as <
   T extends DataDisplayItem,
 >(
-  props: DataDisplayProps<T> & { ref?: React.Ref<DataDisplayRef> }
+  props: DataDisplayProps<T> & React.RefAttributes<DataDisplayRef>
 ) => ReturnType<typeof DataDisplayComponent>;


### PR DESCRIPTION
## Description
Enhances the `data-display.tsx` with `forwardRef` support, enabling parent components to access internal table state (filters, sorting, global search) and control methods through a ref.

Changes Made
1. New `DataDisplayRef` Interface
Exposes read-only state and imperative reset methods to parent components.

2. Ref Implementation
Uses `React.useImperativeHandle`

State access: `columnFilters`, `sorting`, `globalFilter`
Control methods: `resetFilters()`,  `resetSorting()`, `resetGlobalFilter()`

```ts
export interface DataDisplayRef {
  columnFilters: ColumnFiltersState;
  sorting: SortingState;
  globalFilter: string;
  resetFilters: () => void;
  resetSorting: () => void;
  resetGlobalFilter: () => void;
}
```

## Usage example
```ts
const MyComponent = () => {
  const dataDisplayRef = useRef<DataDisplayRef>(null);

  const handleClearFilters = () => {
    dataDisplayRef.current?.resetFilters();
    dataDisplayRef.current?.resetGlobalFilter();
  };

  return (
    <>
      <button onClick={handleClearFilters}>Clear All Filters</button>
      <DataDisplay<Course>
        ref={dataDisplayRef}
        urlPath="/courses"
        columns={columns}
        // ... other props
      />
    </>
  );
};
```