### PR TITLE
fix: Update Swagger to use proper merged spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docker:build:web": "cd web && npm run docker:build",
     "docker:down": "docker compose down",
     "docker:restart": "docker compose restart",
-    "generate-api": "turbo run generate-spec && turbo run generate-strapi-client",
+    "generate-api": "turbo run generate-merged-spec && turbo run generate-strapi-client",
     "release:patch": "npm version patch && git push --follow-tags",
     "release:minor": "npm version minor && git push --follow-tags",
     "release:major": "npm version major && git push --follow-tags",

--- a/strapi/.gitignore
+++ b/strapi/.gitignore
@@ -82,6 +82,8 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
+public/openapi/*
+!public/openapi/.gitkeep
 .tsbuildinfo
 .eslintcache
 

--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,7 +1,22 @@
 export default [
   'strapi::logger',
   'strapi::errors',
-  'strapi::security',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'script-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com'],
+          'style-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com'],
+          'connect-src': ["'self'", 'https:'],
+          'img-src': ["'self'", 'data:', 'blob:', 'https:'],
+          'media-src': ["'self'", 'data:', 'blob:'],
+          upgradeInsecureRequests: null,
+        },
+      },
+    },
+  },
   'strapi::cors',
   'strapi::poweredBy',
   'strapi::query',

--- a/strapi/package.json
+++ b/strapi/package.json
@@ -5,8 +5,9 @@
   "description": "A Strapi application",
   "packageManager": "npm@10.2.0",
   "scripts": {
-    "dev": "cross-env ENV_PATH=../.env strapi develop",
-    "build": "strapi build",
+    "dev": "npm run copy-spec && cross-env ENV_PATH=../.env strapi develop",
+    "build": "npm run copy-spec && strapi build",
+    "copy-spec": "node -e \"require('fs').cpSync('../openapi/strapi-spec.json', 'public/openapi/strapi-spec.json', {recursive: true})\"",
     "docker:build": "docker build -t educado-strapi:latest -f Dockerfile ..",
     "docker:build:tag": "docker build -t educado-strapi:$TAG -f Dockerfile ..",
     "test": "echo 'No tests configured for Strapi yet'",
@@ -23,7 +24,7 @@
     "upgrade": "npx @strapi/upgrade latest",
     "upgrade:dry": "npx @strapi/upgrade latest --dry",
     "generate-spec": "cross-env ENV_PATH=../.env strapi openapi generate --output ../openapi/strapi-spec.json",
-    "generate-merged-spec": "cross-env ENV_PATH=../.env strapi openapi generate --output ../openapi/strapi-spec.json && ts-node src/extensions/documentation/run-merge-spec.ts"
+    "generate-merged-spec": "cross-env ENV_PATH=../.env strapi openapi generate --output ../openapi/strapi-spec.json && ts-node src/extensions/documentation/run-merge-spec.ts && npm run copy-spec"
   },
   "dependencies": {
     "@strapi/plugin-cloud": "5.30.0",

--- a/strapi/public/openapi.html
+++ b/strapi/public/openapi.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Educado API Documentation</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui.css"
+    />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.onload = function () {
+        SwaggerUIBundle({
+          url: "/openapi/strapi-spec.json",
+          dom_id: "#swagger-ui",
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          layout: "StandaloneLayout",
+        });
+      };
+    </script>
+  </body>
+</html>

--- a/strapi/public/openapi/.gitkeep
+++ b/strapi/public/openapi/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory in git but ignore its contents

--- a/turbo.json
+++ b/turbo.json
@@ -69,7 +69,7 @@
       "outputs": ["src/shared/api/**"]
     },
     "generate-api": {
-      "dependsOn": ["//#generate-spec", "//#generate-client"],
+      "dependsOn": ["//#generate-merged-spec", "//#generate-client"],
       "outputs": []
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -57,8 +57,15 @@
       "dependsOn": [],
       "outputs": ["../openapi/strapi-spec.json"]
     },
+    "generate-merged-spec": {
+      "dependsOn": [],
+      "outputs": [
+        "../openapi/strapi-spec.json",
+        "public/openapi/strapi-spec.json"
+      ]
+    },
     "generate-strapi-client": {
-      "dependsOn": ["^generate-spec"],
+      "dependsOn": ["^generate-merged-spec"],
       "outputs": ["src/shared/api/**"]
     },
     "generate-api": {


### PR DESCRIPTION
## Description

Implements a proper Swagger UI setup to serve our merged OpenAPI specification, addressing the ongoing Strapi OpenAPI regression issues outlined in #67 and #68.

### Problem
- Strapi v5.26–v5.29 has a regression where the built-in OpenAPI/Swagger plugin generates incomplete specs (missing reusable components/schemas)
- We're currently stuck using the deprecated documentation plugin to generate a proper spec
- Our custom endpoints need to be merged with the auto-generated CRUD endpoints
- The built-in Swagger UI only reads the incomplete, non-merged spec

### Solution
This PR sets up a standalone Swagger UI that serves our **merged** OpenAPI specification, giving us complete API documentation while we wait for upstream fixes.

## Changes Made

### 1. Swagger UI Integration
- Added `strapi/public/openapi.html` following [official Strapi docs](https://docs.strapi.io/cms/api/openapi#integrating-with-swagger-ui)
- Configured CSP middleware in `strapi/config/middlewares.ts` to allow Swagger UI assets from unpkg.com
- Points to `/openapi/strapi-spec.json` (our merged spec) instead of the incomplete auto-generated one

### 2. Monorepo File Serving
Since the merged spec lives at the repo root (`/openapi/strapi-spec.json`) but Strapi serves from `strapi/public/`, added:
- New `copy-spec` npm script to copy the spec to `strapi/public/openapi/`
- Updated `dev`, `build`, and `generate-merged-spec` scripts to automatically copy the spec
- Added gitignore rules to prevent committing the copied file

## Usage

### ❌ Don't Use: Built-in Swagger (Incomplete)
The built-in Swagger UI accessible from the admin panel menu serves an **incomplete spec** and will be deprecated:

<img width="2492" alt="Built-in incomplete Swagger" src="https://github.com/user-attachments/assets/65e0bf63-c5a6-47fa-89af-a50a1aacc584" />

### ✅ Do Use: New Swagger UI (Complete & Merged)
Access the complete, merged API documentation at: http://localhost:1337/openapi.html

<img width="1173" alt="New complete Swagger UI with merged spec" src="https://github.com/user-attachments/assets/1720b223-7721-4635-afff-8d68a49b1b39" />

### Generating the client
There are individual scripts for running parts of the generation separately. However in 99% of cases, you should run the command below, which both generates in Backend & Web.

````
npm run generate-api
````

## Technical Notes

- The Swagger UI uses the merged spec that combines:
  - Auto-generated CRUD endpoints from Strapi's deprecated OpenAPI generator (v3.0)
  - Custom endpoints (student auth, etc.)
- Spec generation workflow remains unchanged (see #68)
- This is a temporary solution until [strapi/strapi#24717](https://github.com/strapi/strapi/issues/24717) is resolved

## Testing
- [x] Verify `/openapi.html` loads successfully
- [ ] Confirm merged spec includes both CRUD and custom endpoints
- [ ] Check that custom student auth endpoints are properly documented
- [x] Ensure spec updates when running `npm run generate-merged-spec`
