### PR TITLE
feat: add ESLint diffing tool to check only changed files

### DIFF
--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -24,6 +24,7 @@ export default [
       "node_modules/",
       "__tests__/",
       "cypress/",
+      "scripts/",
       "vite.config.ts",
       "tailwind.config.cjs",
       "postcss.config.js",
@@ -85,6 +86,8 @@ export default [
     },
     // Our custom rules and overrides.
     rules: {
+      // Disable unified-signatures rule due to crashes in @typescript-eslint/eslint-plugin
+      "@typescript-eslint/unified-signatures": "off",
       // Prevents bugs from using "truthy" or "falsy" values in conditions.
       "@typescript-eslint/strict-boolean-expressions": [
         "error",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,8 @@
     "test": "cross-env ENV_PATH=../.env jest --verbose --runInBand --detectOpenHandles",
     "lint:check": "cross-env ENV_PATH=../.env eslint .",
     "lint:fix": "cross-env ENV_PATH=../.env eslint --fix .",
+    "lint:check:changed": "node scripts/lint-changed.js",
+    "lint:fix:changed": "node scripts/lint-changed.js --fix",
     "format:check": "prettier --check \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx}\"",
     "format:fix": "prettier --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx}\"",
     "type-check": "tsc --noEmit",

--- a/web/scripts/lint-changed.js
+++ b/web/scripts/lint-changed.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __root = path.resolve(__dirname, "..");
+
+// Check if --fix flag is passed
+const shouldFix = process.argv.includes("--fix");
+
+try {
+  // Get changed files compared to origin/dev
+  const changedFiles = execSync(
+    "git diff --name-only --diff-filter=d origin/dev HEAD",
+    { cwd: __root, encoding: "utf-8" }
+  )
+    .split("\n")
+    .filter((file) => file.trim())
+    // Only lint TypeScript/TSX files
+    .filter((file) => /\.(ts|tsx)$/.test(file))
+    // Filter to only files in the web directory (since we're running from web workspace)
+    .filter((file) => file.startsWith("web/") || file.startsWith("web\\"))
+    // Remove 'web/' prefix since we're already in the web directory
+    .map((file) => file.replace(/^web[/\\]/, ""))
+    // Filter out test files and config files if needed
+    .filter((file) => !file.includes("node_modules"))
+    .map((file) => path.join(__root, file));
+
+  if (changedFiles.length === 0) {
+    console.log("No TypeScript files changed in web/ compared to origin/dev");
+    process.exit(0);
+  }
+
+  console.log(`Found ${changedFiles.length} changed TypeScript file(s):`);
+  for (const file of changedFiles) {
+    console.log(`  - ${path.relative(__root, file)}`);
+  }
+  console.log();
+
+  // Run ESLint on changed files
+  const eslintCmd = [
+    "cross-env ENV_PATH=../.env eslint",
+    shouldFix ? "--fix" : "",
+    ...changedFiles.map((file) => `"${file}"`),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  execSync(eslintCmd, { cwd: __root, stdio: "inherit" });
+  process.exit(0);
+} catch (error) {
+  // execSync throws if the command exits with non-zero code
+  // We want to let ESLint's exit code through
+  if (error.status !== undefined) {
+    process.exit(error.status);
+  }
+  console.error("Error:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

While working on another branch, i wanted to check ESLint errors for my changes only.

This PR introduces a small utility script which runs a GIT diff and feeds the changed files to ESLint.

Becuase there's currently so many ESLint errors, it is difficult to see if MY work introduces regressions and issues.

### Changes made
1. Added two npm commands to web

```
    "lint:check:changed": "node scripts/lint-changed.js",
    "lint:fix:changed": "node scripts/lint-changed.js --fix",
```
2. Add a `lint-changed.js` script (Not TS so it doesnt have to be transpiled) which does the diffing.
3. Fixes a config error in ESLint which causes it to crash.