### PR TITLE
Make lastName required for Content Creator

### DIFF
--- a/openapi/strapi-spec.json
+++ b/openapi/strapi-spec.json
@@ -20549,6 +20549,7 @@
           "data": {
             "required": [
               "firstName",
+              "lastName",
               "email",
               "password",
               "education",
@@ -20720,6 +20721,7 @@
         "type": "object",
         "required": [
           "firstName",
+          "lastName",
           "email",
           "password",
           "education",

--- a/strapi/src/api/content-creator/content-types/content-creator/schema.json
+++ b/strapi/src/api/content-creator/content-types/content-creator/schema.json
@@ -20,7 +20,8 @@
     "lastName": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 50
+      "maxLength": 50,
+      "required": true
     },
     "verifiedAt": {
       "type": "date"

--- a/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-11-17T11:42:19.267Z"
+    "x-generation-date": "2025-11-24T12:59:35.139Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -10060,6 +10060,7 @@
           "data": {
             "required": [
               "firstName",
+              "lastName",
               "email",
               "password",
               "education",
@@ -10231,6 +10232,7 @@
         "type": "object",
         "required": [
           "firstName",
+          "lastName",
           "email",
           "password",
           "education",

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -526,6 +526,7 @@ export interface ApiContentCreatorContentCreator
         minLength: 1;
       }>;
     lastName: Schema.Attribute.String &
+      Schema.Attribute.Required &
       Schema.Attribute.SetMinMaxLength<{
         maxLength: 50;
         minLength: 1;


### PR DESCRIPTION
Currently Lastname for the content creator is requird in the code but not in the strapi, so you can make a content creator without lastname, and it would crach the web without any explaination. 

this PR changes the Lastname in Strapi to be required to avoid future problems.  