### PR TITLE
Remove Eslint/strict boolean rule

### DIFF
--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -88,11 +88,6 @@ export default [
     rules: {
       // Disable unified-signatures rule due to crashes in @typescript-eslint/eslint-plugin
       "@typescript-eslint/unified-signatures": "off",
-      // Prevents bugs from using "truthy" or "falsy" values in conditions.
-      "@typescript-eslint/strict-boolean-expressions": [
-        "error",
-        { allowString: false, allowNumber: false, allowNullableObject: true },
-      ],
       // Prevents `console.log` (In prod), but allows `console.warn` and `console.error`.
       "no-console": ["error", { allow: ["warn", "error"] }],
       // Enforces the project's coding conventions for naming variables, functions, etc.


### PR DESCRIPTION
## Description

This PR removes the `"@typescript-eslint/strict-boolean-expressions"` rule. It’s a bigger PITA than it is protective in our codebase, creating noise and churn for common patterns.

Examples of why it’s annoying:
- Conditional render (blocked for no real gain):
  - Rejected: `{myVar && <Component />}`
    - In this expression, the component is ALWAYS "true"
  - Forced: `{Boolean(myVar) && <Component />}` or `{myVar !== null && <Component />}`
- Simple guard clause (needlessly verbose):
  - Rejected: `if (config && config.enabled) doThing();`
  - Forced: `if (config?.enabled === true) doThing();`

Net result: extra casts and verbosity without added safety. Types and strict null checks already cover the meaningful cases.