### PR TITLE
Added a (pre)vious slide function that was missing for some reason

### DIFF
--- a/web/src/unplaced/archive/Carousel.tsx
+++ b/web/src/unplaced/archive/Carousel.tsx
@@ -50,6 +50,12 @@ const Carousel: React.FC = () => {
     }
   };
 
+  const pre = () => {
+    setCurrentIndex((prevIndex) =>
+      (prevIndex - 1 + texts.length) % texts.length
+    );
+  };
+
   //Timer that decides when the text automatically changes
   useEffect(() => {
     const intervalId = setInterval(next, 8000);


### PR DESCRIPTION
On dev, if you logged out of your user on the Web Application, your program would crash and you would be unable to login again.

This bug happened on the basis of a missing function in the Carousel.tsx file. The "Carousel" or gallery used to flip through text was missing the function for going left on the carousel,.

This hotfix simply adds this function, such that dev no longer will crash if you log out of your account on the website.