### PR TITLE
fix: Add sharp musl support for Strapi Alpine runtime

### DIFF
--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -26,10 +26,13 @@ COPY --from=pruner /app/out/package-lock.json ./package-lock.json
 RUN npm install -g node-gyp
 
 # Install dependencies, then explicitly install musl-compatible native binaries
-# This fixes native module issues on Alpine (@swc/core for TS, @rollup for Vite/admin build)
+# This fixes native module issues on Alpine:
+# - @swc/core for TypeScript compilation
+# - @rollup for Vite/admin build
+# - sharp for image processing (used by @strapi/upload)
 RUN npm config set fetch-retry-maxtimeout 600000 -g && \
     npm ci && \
-    npm install @swc/core-linux-x64-musl @rollup/rollup-linux-x64-musl --no-save || true
+    npm install @swc/core-linux-x64-musl @rollup/rollup-linux-x64-musl sharp --os=linux --libc=musl --cpu=x64 --no-save || true
 
 # Stage 3: Build the application
 FROM node:22-alpine AS builder


### PR DESCRIPTION
## Summary
Follow-up fix to #148 (Alpine/musl native binary compatibility).

The sharp module used by `@strapi/upload` was missing its musl-compatible binaries, causing the Strapi container to crash on startup:
```
Could not load the "sharp" module using the linuxmusl-x64 runtime
```

## Changes
- Added `sharp` to the musl-compatible native binary install command with `--os=linux --libc=musl --cpu=x64` flags

## Related
- Extends #148