### PR TITLE
Fix media picker and full-screen preview issues

### DIFF
--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -182,6 +182,8 @@
     "uploadSuccess": "File uploaded successfully",
     "uploadFileSuccess": "Uploaded: {{filename}}",
     "filesRejectedType": "{{count}} file(s) rejected: unsupported file type",
+    "filesRejectedSize": "{{count}} file(s) rejected: exceeds {{maxSize}}MB limit",
+    "maxFileSizeHint": "File must be at most {{maxSize}}MB",
     "dragAndDrop": "Drag and drop files here, or click to select",
     "browseFiles": "Browse Files",
     "browseLibrary": "Browse Library",

--- a/web/i18n/locales/pt.json
+++ b/web/i18n/locales/pt.json
@@ -182,6 +182,8 @@
     "uploadSuccess": "Arquivo enviado com sucesso",
     "uploadFileSuccess": "Enviado: {{filename}}",
     "filesRejectedType": "{{count}} arquivo(s) rejeitado(s): tipo de arquivo não suportado",
+    "filesRejectedSize": "{{count}} arquivo(s) rejeitado(s): excede o limite de {{maxSize}}MB",
+    "maxFileSizeHint": "O arquivo deve conter no máximo {{maxSize}}MB",
     "dragAndDrop": "Arraste e solte arquivos aqui, ou clique para selecionar",
     "browseFiles": "Procurar Arquivos",
     "browseLibrary": "Procurar Biblioteca",

--- a/web/src/features/media/components/image-fullscreen-preview.tsx
+++ b/web/src/features/media/components/image-fullscreen-preview.tsx
@@ -82,6 +82,18 @@ export const ImageFullscreenPreview = ({
     }
   }, [isOpen]);
 
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
   // Handle zoom
   const handleZoomIn = () => {
     setScale((prev) => Math.min(prev + 0.5, 5));
@@ -208,9 +220,10 @@ export const ImageFullscreenPreview = ({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/95 border-none"
+        className="absolute h-screen inset-0 bg-black/95 border-none"
         onClick={onClose}
         onKeyDown={(e) => {
+          e.stopPropagation();
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onClose();

--- a/web/src/features/media/components/media-picker-modal.tsx
+++ b/web/src/features/media/components/media-picker-modal.tsx
@@ -29,6 +29,8 @@ interface MediaPickerModalProps {
   fileTypes?: MediaFileType | MediaFileType[];
   /** Maximum number of files for upload. Defaults to 1. */
   maxFiles?: number;
+  /** Maximum file size in bytes. */
+  maxFileSize?: number;
 }
 
 const MediaPickerModal = ({
@@ -37,6 +39,7 @@ const MediaPickerModal = ({
   onSelect,
   fileTypes,
   maxFiles = 1,
+  maxFileSize,
 }: MediaPickerModalProps) => {
   const { t } = useTranslation();
   const [selectedAsset, setSelectedAsset] = useState<UploadFile | null>(null);
@@ -66,7 +69,7 @@ const MediaPickerModal = ({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="w-[98vw]! h-[85vh]! max-w-none! p-6 flex flex-col overflow-hidden">
         <Tabs
-          defaultValue="enviar"
+          defaultValue="banco"
           className="w-full h-full flex flex-col min-h-0"
         >
           <TabsList className="shrink-0 w-full grid grid-cols-2 bg-transparent p-0 rounded-none">
@@ -92,6 +95,7 @@ const MediaPickerModal = ({
                 <MediaUploadZone
                   fileTypes={fileTypes}
                   maxFiles={maxFiles}
+                  maxFileSize={maxFileSize}
                   onUploadComplete={handleUploadComplete}
                   uploadButtonLabel={t("media.uploadOnly")}
                   secondaryAction={{

--- a/web/src/features/media/components/media-picker-trigger.tsx
+++ b/web/src/features/media/components/media-picker-trigger.tsx
@@ -21,6 +21,8 @@ interface MediaPickerTriggerProps {
   fileTypes?: MediaFileType | MediaFileType[];
   /** Maximum number of files for upload within the modal. Defaults to 1. */
   maxFiles?: number;
+  /** Maximum file size in bytes. */
+  maxFileSize?: number;
   /** Whether the component is disabled */
   disabled?: boolean;
   /** Additional class names */
@@ -49,6 +51,7 @@ export const MediaPickerTrigger = ({
   onChange,
   fileTypes,
   maxFiles = 1,
+  maxFileSize,
   disabled = false,
   className,
 }: MediaPickerTriggerProps) => {
@@ -84,8 +87,9 @@ export const MediaPickerTrigger = ({
   if (value) {
     return (
       <>
-        <button
-          type="button"
+        <div
+          role="button"
+          tabIndex={disabled ? -1 : 0}
           className={cn(
             "relative w-full h-64 rounded-lg border overflow-hidden group cursor-pointer",
             disabled && "opacity-50 cursor-not-allowed",
@@ -93,7 +97,7 @@ export const MediaPickerTrigger = ({
           )}
           onClick={handleClick}
           onKeyDown={handleKeyDown}
-          disabled={disabled}
+          aria-disabled={disabled}
         >
           <MediaAssetPreview
             asset={value}
@@ -112,7 +116,7 @@ export const MediaPickerTrigger = ({
               <Icon path={mdiClose} size={0.65} />
             </Button>
           )}
-        </button>
+        </div>
 
         <MediaPickerModal
           isOpen={isModalOpen}
@@ -120,6 +124,7 @@ export const MediaPickerTrigger = ({
           onSelect={handleSelect}
           fileTypes={fileTypes}
           maxFiles={maxFiles}
+          maxFileSize={maxFileSize}
         />
       </>
     );
@@ -128,13 +133,14 @@ export const MediaPickerTrigger = ({
   // No value: show the trigger card
   return (
     <>
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
-        disabled={disabled}
+        aria-disabled={disabled}
         className={cn(
-          "relative flex flex-col items-center justify-center rounded-xl border-2 border-dashed p-12 transition-all cursor-pointer min-h-48",
+          "relative flex flex-col items-center justify-center w-full rounded-xl border-2 border-dashed p-12 transition-all cursor-pointer min-h-48",
           "border-border bg-muted/30 hover:border-primary/50 hover:bg-muted/50",
           disabled && "opacity-50 cursor-not-allowed",
           className
@@ -147,10 +153,10 @@ export const MediaPickerTrigger = ({
         <p className="text-sm text-muted-foreground text-center max-w-xs mb-4">
           {t("media.clickToSelect")}
         </p>
-        <Button type="button" variant="secondary" disabled={disabled}>
+        <span className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-9 px-4 py-2">
           {t("media.browseLibrary")}
-        </Button>
-      </button>
+        </span>
+      </div>
 
       <MediaPickerModal
         isOpen={isModalOpen}
@@ -158,6 +164,7 @@ export const MediaPickerTrigger = ({
         onSelect={handleSelect}
         fileTypes={fileTypes}
         maxFiles={maxFiles}
+        maxFileSize={maxFileSize}
       />
     </>
   );

--- a/web/src/features/media/components/media-upload-zone.tsx
+++ b/web/src/features/media/components/media-upload-zone.tsx
@@ -144,6 +144,8 @@ interface MediaUploadZoneProps {
   fileTypes?: MediaFileType | MediaFileType[];
   /** Maximum number of files allowed. */
   maxFiles?: number;
+  /** Maximum file size in bytes. */
+  maxFileSize?: number;
   /** Callback when upload completes successfully */
   onUploadComplete?: (files: UploadFile[]) => void;
   /** Whether the component is disabled */
@@ -170,6 +172,7 @@ interface MediaUploadZoneProps {
 export const MediaUploadZone = ({
   fileTypes,
   maxFiles,
+  maxFileSize,
   onUploadComplete,
   disabled = false,
   className,
@@ -321,7 +324,7 @@ export const MediaUploadZone = ({
 
   return (
     <Form {...form}>
-      <div className={cn("space-y-4", className)}>
+      <div className={cn("space-y-4 w-full", className)}>
         {uploadError && (
           <ErrorDisplayWithRetry
             error={uploadError}
@@ -333,6 +336,7 @@ export const MediaUploadZone = ({
         <MediaUploadCard
           fileTypes={fileTypes}
           maxFiles={maxFiles}
+          maxFileSize={maxFileSize}
           onFilesSelected={handleFilesSelected}
           disabled={isDisabled}
         />

--- a/web/src/features/media/pages/media-overview-page.tsx
+++ b/web/src/features/media/pages/media-overview-page.tsx
@@ -49,7 +49,7 @@ const MediaOverviewPage = () => {
           </CardHeader>
           <CardContent>
             {showUploader && (
-              <div className="mb-6 space-y-4">
+              <div className="mb-6 space-y-4 w-full">
                 <MediaUploadZone
                   onUploadComplete={() => {
                     void handleUploadComplete();

--- a/web/src/shared/components/form/form-file-upload.tsx
+++ b/web/src/shared/components/form/form-file-upload.tsx
@@ -10,11 +10,17 @@ import type { MediaFileType } from "@/features/media/lib/media-utils";
 import type { UploadFile } from "@/shared/api/types.gen";
 import { cn } from "@/shared/lib/utils";
 
+import { FormDescription, FormLabel } from "../shadcn/form";
+
 interface FormFileUploadProps<T extends FieldValues> {
   name: Path<T>;
   control: Control<T>;
+  label?: string;
+  description?: string;
+  isRequired?: boolean;
   fileTypes?: MediaFileType | MediaFileType[];
   maxFiles?: number;
+  maxFileSize?: number;
   disabled?: boolean;
   className?: string;
 }
@@ -26,8 +32,12 @@ interface FormFileUploadProps<T extends FieldValues> {
 export const FormFileUpload = <T extends FieldValues>({
   name,
   control,
+  label,
+  description,
+  isRequired,
   fileTypes,
   maxFiles = 1,
+  maxFileSize,
   disabled = false,
   className,
 }: FormFileUploadProps<T>) => {
@@ -56,13 +66,18 @@ export const FormFileUpload = <T extends FieldValues>({
 
   return (
     <div className={cn("space-y-2", className)}>
+      {label && <FormLabel required={isRequired}>{label}</FormLabel>}
       <MediaPickerTrigger
         value={singleValue}
         onChange={handleChange}
         fileTypes={fileTypes}
         maxFiles={maxFiles}
+        maxFileSize={maxFileSize}
         disabled={disabled}
       />
+      {description && (
+        <FormDescription className="text-right">{description}</FormDescription>
+      )}
       {error && <p className="text-sm text-destructive">{error.message}</p>}
     </div>
   );

--- a/web/src/shared/data-display/hooks/used-paginated-data.ts
+++ b/web/src/shared/data-display/hooks/used-paginated-data.ts
@@ -22,7 +22,7 @@ import {
 } from "../lib/query-params-builder";
 import { PaginatedData } from "../types/paginated-data";
 
-const LOGGING_ENABLED = true;
+const LOGGING_ENABLED = false;
 
 /* ----------------------------- Exported types ----------------------------- */
 


### PR DESCRIPTION
## Summary

This PR addresses several UI/UX issues related to the media picker and full-screen preview components.

## Changes

### Full-Screen Preview Fixes
- Fixed an issue with the full-screen preview showing whitespace below the backdrop
- Fixed an issue where the background of the full-screen preview would scroll through

### Media Picker Improvements
- Fixed full width media picker and upload zone in media-overview-page and course-editor-information
- Set default asset picker mode to "Library" instead of "Upload"

### Form File Upload Enhancement
- Added `label`, `description`, and `required` props to `form-file-upload` component to match the Figma prototype

### Other
- Disabled logging in `use-paginated-data` hook

## Testing
- Verified full-screen preview no longer shows whitespace below backdrop
- Verified background doesn't scroll when full-screen preview is open
- Verified media picker displays at full width in affected pages
- Verified form-file-upload renders label, description, and required indicator correctly