### PR TITLE
Fix course creation form with proper relation handling

### DIFF
--- a/strapi/src/api/course/controllers/course.ts
+++ b/strapi/src/api/course/controllers/course.ts
@@ -29,5 +29,80 @@ export default factories.createCoreController(
 
       return this.transformResponse(result);
     },
+
+    async create(ctx) {
+      const { data } = ctx.request.body;
+
+      // Extract relations (document IDs from the request)
+      const categoryDocumentIds: string[] = data?.course_categories ?? [];
+      const imageDocumentId: string | undefined = data?.image;
+
+      // Look up internal ID for image if provided
+      let imageId: number | undefined;
+      if (imageDocumentId) {
+        const image = await strapi.db.query('plugin::upload.file').findOne({
+          where: { documentId: imageDocumentId },
+        });
+        imageId = image?.id;
+      }
+
+      // Create the course with relations
+      const result = await strapi.documents('api::course.course').create({
+        data: {
+          title: data?.title,
+          description: data?.description,
+          difficulty: data?.difficulty,
+          durationHours: data?.durationHours ?? 0,
+          numOfRatings: data?.numOfRatings ?? 0,
+          numOfSubscriptions: data?.numOfSubscriptions ?? 0,
+          image: imageId,
+          ...(categoryDocumentIds.length > 0 && {
+            course_categories: { set: categoryDocumentIds },
+          }),
+        },
+        status: ctx.query?.status as 'draft' | 'published' | undefined,
+        populate: ['course_categories', 'image'],
+      });
+
+      return this.transformResponse(result);
+    },
+
+    async update(ctx) {
+      const { id } = ctx.params; // This is the documentId
+      const { data } = ctx.request.body;
+
+      // Extract relations (document IDs from the request)
+      const categoryDocumentIds: string[] | undefined = data?.course_categories;
+      const imageDocumentId: string | undefined = data?.image;
+
+      // Look up internal ID for image if provided
+      let imageId: number | undefined;
+      if (imageDocumentId) {
+        const image = await strapi.db.query('plugin::upload.file').findOne({
+          where: { documentId: imageDocumentId },
+        });
+        imageId = image?.id;
+      }
+
+      // Update the course with relations
+      const result = await strapi.documents('api::course.course').update({
+        documentId: id,
+        data: {
+          title: data?.title,
+          description: data?.description,
+          difficulty: data?.difficulty,
+          durationHours: data?.durationHours ?? 0,
+          numOfRatings: data?.numOfRatings,
+          numOfSubscriptions: data?.numOfSubscriptions,
+          image: imageId,
+          ...(categoryDocumentIds !== undefined && {
+            course_categories: { set: categoryDocumentIds },
+          }),
+        },
+        populate: ['course_categories', 'image'],
+      });
+
+      return this.transformResponse(result);
+    },
   })
 );

--- a/web/src/features/course/api/course-queries.ts
+++ b/web/src/features/course/api/course-queries.ts
@@ -1,4 +1,3 @@
-import { client } from "@/shared/api/client.gen";
 import { courseGetCoursesById } from "@/shared/api/sdk.gen";
 import type { Course } from "@/shared/api/types.gen";
 
@@ -29,8 +28,8 @@ export const CourseQueryFunction = (courseId: string) => ({
           "updatedAt",
           "publishedAt",
         ],
-        // Use "*" to populate all relations with their full data including nested fields
-        populate: "course_categories",
+        // Populate relations with their full data
+        populate: ["course_categories", "image"],
       },
     });
 


### PR DESCRIPTION
## Summary

This PR fixes the course creation/editing form to properly handle relations (categories and images) when saving to Strapi.

## Changes

### Strapi Controller (`strapi/src/api/course/controllers/course.ts`)
- Added custom `create` and `update` controller methods to properly handle relation document IDs
- Image relations now correctly look up internal IDs from document IDs before saving
- Category relations use the `{ set: documentIds }` syntax for proper Strapi 5 relation handling
- Both methods populate `course_categories` and `image` relations in the response

### Frontend Form (`course-editor-information.tsx`)
- Renamed form field from `categories` to `course_categories` to match the API schema
- Simplified the Zod schema - removed unnecessary `.optional().refine()` chain
- Fixed form reset to use `course_categories` field name consistently
- Updated all `setError`, `setFocus`, and `clearErrors` calls to use correct field name
- Changed image handling to use `documentId` instead of `id` for Strapi 5 compatibility
- Added `eslint-disable` directive for naming convention at file level
- Added label, description, and isRequired props to FormFileUpload

### Course Queries (`course-queries.ts`)
- Updated populate parameter to include both `course_categories` and `image` as an array
- Removed unused `client` import

## Dependencies

This PR depends on #153 (web/media-fixes) for the FormFileUpload component changes.

## Testing
- Verified course creation works with categories and image
- Verified course editing properly loads and saves relations
- Verified form validation works correctly for required fields