### PR TITLE
Deprecated SWR - migrated to TanStack Query

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -70,7 +70,6 @@
     "react-router-dom": "^6.4.1",
     "react-toastify": "^9.0.8",
     "sonner": "^2.0.7",
-    "swr": "^1.3.0",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.4.0",
     "usehooks-ts": "^2.9.1",

--- a/web/src/unplaced/Admin/Institutions/Actions/DeleteInstitutionsButton.tsx
+++ b/web/src/unplaced/Admin/Institutions/Actions/DeleteInstitutionsButton.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import Icon from "@mdi/react";
 import { mdiDelete } from "@mdi/js";
 import { toast } from "react-toastify";
-import { KeyedMutator } from "swr";
 
 import { getUserToken } from "@/features/auth/lib/userInfo";
 import { Institution } from "@/features/user/types/Institution";
@@ -16,7 +15,7 @@ export const DeleteInstitutionButton = ({
   refreshFn,
 }: {
   institutionId: string;
-  refreshFn: KeyedMutator<Institution[]>;
+  refreshFn: () => void | Promise<unknown>;
 }) => {
   const [showModal, setShowModal] = useState(false);
   const { call: deleteInstitution, isLoading } = useApi(
@@ -28,7 +27,7 @@ export const DeleteInstitutionButton = ({
   const handleConfirm = async () => {
     try {
       await deleteInstitution(institutionId, getUserToken());
-      refreshFn();
+      await refreshFn();
       addNotification("Instituição deletada com sucesso !");
     } catch (err) {
       toast.error(err as string);

--- a/web/src/unplaced/Admin/Institutions/Actions/UpdateInstitutionsButton.tsx
+++ b/web/src/unplaced/Admin/Institutions/Actions/UpdateInstitutionsButton.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, FormEvent } from "react";
 import Icon from "@mdi/react";
 import { mdiPencil } from "@mdi/js";
 import { toast } from "react-toastify";
-import { KeyedMutator } from "swr";
 
 import { getUserToken } from "@/auth/lib/userInfo";
 import GenericModalComponent from "@/shared/components/GenericModalComponent";
@@ -16,7 +15,7 @@ export const UpdateInstitutionButton = ({
   refreshFn,
 }: {
   institution: Institution;
-  refreshFn: KeyedMutator<Institution[]>;
+  refreshFn: () => void | Promise<unknown>;
 }) => {
   const [showModal, setShowModal] = useState(false);
 
@@ -30,11 +29,14 @@ export const UpdateInstitutionButton = ({
     institutionService.updateInstitution
   );
 
+  // Reset inputs whenever the modal opens or the institution changes
   useEffect(() => {
-    setNameInput(institution.institutionName);
-    setDomainInput(institution.domain);
-    setSecondaryDomainInput(institution.secondaryDomain);
-  }, [showModal]);
+    if (showModal) {
+      setNameInput(institution.institutionName);
+      setDomainInput(institution.domain);
+      setSecondaryDomainInput(institution.secondaryDomain);
+    }
+  }, [showModal, institution]);
 
   const { addNotification } = useNotifications();
 
@@ -54,7 +56,7 @@ export const UpdateInstitutionButton = ({
         secondaryDomain: secondaryDomainInput,
       });
 
-      refreshFn();
+      await refreshFn();
       setShowModal(false);
       addNotification("Instituição atualizada com sucesso !");
     } catch (err) {
@@ -115,7 +117,7 @@ export const UpdateInstitutionButton = ({
                   type="text"
                   name="domain"
                   required
-                  pattern="@([\w\-]+\.)+[\w\-]{2,4}"
+                  pattern="@([\\w\\-]+\\.)+[\\w\\-]{2,4}"
                   title="@domain.com"
                   placeholder="@domain.com"
                   value={domainInput}
@@ -133,7 +135,7 @@ export const UpdateInstitutionButton = ({
                   name="secondary-domain"
                   placeholder="@domain.com (opcional)"
                   title="@domain.com (opcional)"
-                  pattern="@([\w\-]+\.)+[\w\-]{2,4}$"
+                  pattern="@([\\w\\-]+\\.)+[\\w\\-]{2,4}$"
                   value={secondaryDomainInput}
                   onChange={(e) => {
                     setSecondaryDomainInput(e.target.value);

--- a/web/src/unplaced/Admin/Institutions/InstitutionsTableAdmin.tsx
+++ b/web/src/unplaced/Admin/Institutions/InstitutionsTableAdmin.tsx
@@ -5,9 +5,9 @@ import {
   mdiChevronLeft,
   mdiChevronRight,
   mdiArrowRight,
+  mdiMagnify,
 } from "@mdi/js";
-import { mdiMagnify } from "@mdi/js";
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
 
 import { getUserToken } from "@/auth/lib/userInfo";
 import Loading from "@/shared/components/Loading";
@@ -23,17 +23,30 @@ export const InstitutionsTableAdmin = () => {
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
   const userToken = getUserToken();
-  const { data: institutionsResponse, mutate } = useSWR(
-    "api/institutions",
-    () => institutionService.getInstitutions(userToken)
-  );
+  const {
+    data: institutionsResponse,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ["institutions", userToken],
+    queryFn: () => institutionService.getInstitutions(userToken),
+    enabled: !!userToken,
+  });
 
-  if (!institutionsResponse) return <Loading />;
+  if (isLoading || !institutionsResponse) return <Loading />;
+
+  if (isError) {
+    return (
+      <div className="container mx-auto flex justify-center items-center py-10">
+        <p className="text-red-500">Erro ao carregar instituições.</p>
+      </div>
+    );
+  }
 
   const filteredData = institutionsResponse.filter((institution) => {
     if (searchTerm === "") return institution;
 
-    // this will be typed in a better way when a hook is made
     const fieldsToCheck = [
       "institutionName",
       "domain",
@@ -141,13 +154,13 @@ export const InstitutionsTableAdmin = () => {
                     <div>
                       <UpdateInstitutionButton
                         institution={institution}
-                        refreshFn={mutate}
+                        refreshFn={refetch}
                       />
                     </div>
                     <div>
                       <DeleteInstitutionButton
                         institutionId={institution._id!}
-                        refreshFn={mutate}
+                        refreshFn={refetch}
                       />
                     </div>
                   </div>

--- a/web/src/unplaced/Admin/Users/UsersTableAdmin.tsx
+++ b/web/src/unplaced/Admin/Users/UsersTableAdmin.tsx
@@ -6,7 +6,7 @@ import {
   mdiChevronRight,
   mdiArrowRight,
 } from "@mdi/js";
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
 
 import { getUserToken } from "@/auth/lib/userInfo";
 import Loading from "@/shared/components/Loading";
@@ -24,14 +24,24 @@ export const UsersTableAdmin = () => {
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
   const userToken = getUserToken();
-  const { data, mutate } = useSWR("api/user-info", () =>
-    AdminServices.getUserApplications(userToken)
-  );
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["user-info", userToken],
+    queryFn: () => AdminServices.getUserApplications(userToken),
+    enabled: !!userToken,
+  });
 
-  if (!data) return <Loading />;
+  if (isLoading || !data) return <Loading />;
+
+  if (isError) {
+    return (
+      <div className="flex justify-center items-center py-10">
+        <p className="text-red-500">Erro ao carregar usuários.</p>
+      </div>
+    );
+  }
 
   const refreshUsers = () => {
-    mutate();
+    void refetch();
   };
 
   const formatDate = (dateString: string) => {
@@ -81,8 +91,7 @@ export const UsersTableAdmin = () => {
     setCurrentPage(totalPages);
   };
 
-  const filteredData = data.filter((userRecord) => {
-    // this will be typed in a better way when a hook is made
+  const filteredData = data.filter((userRecord: UserRecord) => {
     const fieldsToCheck = ["firstName", "lastName", "email"] as const;
 
     return fieldsToCheck.some((field) => {
@@ -157,7 +166,7 @@ export const UsersTableAdmin = () => {
           </tr>
         </thead>
         <tbody>
-          {paginatedData.map((userRecord, key) => {
+          {paginatedData.map((userRecord: UserRecord, key: number) => {
             return (
               <tr
                 key={key}

--- a/web/src/unplaced/SingleApplicantView.tsx
+++ b/web/src/unplaced/SingleApplicantView.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
 
 // Services
 
@@ -28,17 +28,50 @@ const SingleApplicantView = () => {
   const [isRejecting, setIsRejecting] = useState(false);
   const [isAccepting, setIsAccepting] = useState(false);
 
-  //Get data from the relevant route
-  const { data } = useSWR(id, AuthServices.GetSingleCCApplication);
+  // Get data from the relevant route using TanStack Query
+  const {
+    data,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["single-cc-application", id],
+    queryFn: () => AuthServices.GetSingleCCApplication(id!),
+    enabled: !!id,
+  });
 
   const { addNotification } = useNotifications();
+
+  // Navigate away if application does not exist
+  useEffect(() => {
+    if (!isLoading && data && data.data.application == undefined) {
+      navigate("/educado-admin/applications");
+      setTimeout(() => {
+        toast.error("Este usuário não tem candidatura", {
+          hideProgressBar: true,
+        });
+      }, 1);
+    }
+  }, [isLoading, data, navigate]);
+
+  // Loading & error states
+  if (isLoading || !data) return <Loading />;
+
+  if (isError) {
+    return (
+      <Layout meta={`Applicant: ${id?.slice(0, 10)}.`}>
+        <div className="grid place-items-center h-screen pt-20">
+          <p className="text-red-500">Erro ao carregar a candidatura.</p>
+        </div>
+      </Layout>
+    );
+  }
 
   //Function to execute upon accepting an application
   //It will navigate to the applicaitons page, and display a toastify message notifying the user that the content creator was approved
   const handleAccept = async () => {
     setIsAccepting(true); // Set accepting state to true
     AuthServices.AcceptApplication(id!)
-      .then((res) => {
+      .then(() => {
         navigate("/educado-admin/applications");
         addNotification(
           data?.data.applicator.firstName +
@@ -87,21 +120,8 @@ const SingleApplicantView = () => {
       });
   };
 
-  // If no data is found, or until the data is found, show loading page
-  if (!data) return <Loading />;
-
-  // When attempting to view an application that does not exist, user will be navigated back to the applications page
-  if (data?.data.application == undefined) {
-    navigate("/educado-admin/applications");
-    setTimeout(() => {
-      toast.error("Este usuário não tem candidatura", {
-        hideProgressBar: true,
-      });
-    }, 1);
-  }
-
   return (
-    <Layout meta={`Applicant: ${id?.slice(0, 10)}...`}>
+    <Layout meta={`Applicant: ${id?.slice(0, 10)}.`}>
       <div className="grid place-items-center h-screen pt-20">
         <div className="bg-white shadow-sm overflow-hidden rounded-xl">
           <div className="px-4 py-8 sm:px-10">
@@ -157,7 +177,7 @@ const SingleApplicantView = () => {
                     <path
                       className="opacity-75"
                       fill="currentColor"
-                      d="M4 12a8 8 0 018-8v8H4z"
+                      d="M4 12a 8 8 0 018-8v8H4z"
                     />
                   </svg>
                   Processando...


### PR DESCRIPTION


Migrate SWR to TanStack Query

This PR replaces all remaining SWR usage with TanStack Query for consistency across the web app.

What’s included:

Converted SWR-based components to use useQuery + refetch.

Removed KeyedMutator props in favor of simple refreshFn callbacks.

Removed the direct "swr" dependency from web/package.json.

Notes:

The former SWR files are still present, but now use TanStack Query.

If approved by the tech leads, these files can be cleaned up or removed in a follow-up PR.

A nested swr version may still appear in the lockfile due to @ai-sdk/react; this is expected and not used by our code.

Testing:

Verified data loading and refetch behavior in applicant, institutions, and users admin views.

Is a replacement of the old deprecate SWR #101 
