### PR TITLE
fix: add all missing @radix-ui/react-use-* packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37169,7 +37169,12 @@
     "strapi": {
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-use-callback-ref": "^1.1.1",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
+        "@radix-ui/react-use-escape-keydown": "^1.1.1",
+        "@radix-ui/react-use-previous": "^1.1.1",
+        "@radix-ui/react-use-rect": "^1.1.1",
+        "@radix-ui/react-use-size": "^1.1.1",
         "@strapi/plugin-cloud": "5.31.3",
         "@strapi/plugin-documentation": "5.31.3",
         "@strapi/plugin-users-permissions": "5.31.3",

--- a/strapi/package.json
+++ b/strapi/package.json
@@ -27,7 +27,12 @@
     "generate-merged-spec": "cross-env ENV_PATH=../.env strapi openapi generate --output ../openapi/strapi-spec.json && ts-node src/extensions/documentation/run-merge-spec.ts && npm run copy-spec"
   },
   "dependencies": {
+    "@radix-ui/react-use-callback-ref": "^1.1.1",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@radix-ui/react-use-escape-keydown": "^1.1.1",
+    "@radix-ui/react-use-previous": "^1.1.1",
+    "@radix-ui/react-use-rect": "^1.1.1",
+    "@radix-ui/react-use-size": "^1.1.1",
     "@strapi/plugin-cloud": "5.31.3",
     "@strapi/plugin-documentation": "5.31.3",
     "@strapi/plugin-users-permissions": "5.31.3",


### PR DESCRIPTION
Adds remaining hoisted @radix-ui utility packages that turbo prune was missing.